### PR TITLE
Add configuration to run `ruff` with `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        types_or: [python]
+        args: [--fix]
+      - id: ruff-format
+        types_or: [python]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pygmsh
 
 # Dev
 pre-commit
+ruff
 
 # Documentation
 mkdocs==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ matplotlib
 plotly
 pygmsh
 
+# Dev
+pre-commit
+
 # Documentation
 mkdocs==1.5.3
 mkdocs-include-markdown-plugin==3.7.1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+# We exclude the notebooks folder because syntax errors in some of the cells prevent ruff from
+# running
+exclude = ["notebooks"]
+
+[lint]
+select = [
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "I",   # isort
+    "RUF", # ruff
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,5 +7,6 @@ select = [
     "E",   # pycodestyle
     "F",   # Pyflakes
     "I",   # isort
+    "N",   # pep8-naming
     "RUF", # ruff
 ]


### PR DESCRIPTION
This PR adds some configuration files so you can run `ruff` via `pre-commit`.

To use it:

1. Install the new dependencies with `pip install -r requirements.txt`
2. Enable `pre-commit` for your (local) repo by running `pre-commit install`

Now, every time you make a commit, `pre-commit` will check the changes with the hooks I've listed below. (Besides `ruff` there are a few that trim trailing whitespace etc.) I've excluded the Jupyter notebooks for now because they have syntax errors that cause `ruff` to trip up.

Note that `ruff` will give some warnings about the code as it currently stands in the repo, but I haven't fixed these up as I didn't want merge conflicts with your other branch. When you update that branch though, you should run `pre-commit` over everything and fix the warnings. You can do this with:

```
pre-commit run -a
```

Some will need to be manually fixed. I've enabled some checks related to naming conventions (they're the `N` checks in `ruff.toml`) in case that's useful to you, **but** fixing the names of everything really isn't a priority so if e.g. you don't want to bother renaming all your variables, then just comment out this line in the config file and commit it.